### PR TITLE
add usefull module

### DIFF
--- a/2.4.41/run-openldap.sh
+++ b/2.4.41/run-openldap.sh
@@ -52,6 +52,7 @@ if [ ! -f /etc/openldap/CONFIGURED ]; then
         # add useful schemas
         ldapadd -Y EXTERNAL -H ldapi:/// -f /etc/openldap/schema/cosine.ldif -d $OPENLDAP_DEBUG_LEVEL
         ldapadd -Y EXTERNAL -H ldapi:/// -f /etc/openldap/schema/inetorgperson.ldif -d $OPENLDAP_DEBUG_LEVEL
+        ldapadd -Y EXTERNAL -H ldapi:/// -f /etc/openldap/schema/nis.ldif -d $OPENLDAP_DEBUG_LEVEL
 
         # load memberOf and refint modules
         ldapadd -Y EXTERNAL -H ldapi:/// -f /usr/local/etc/openldap/load_modules.ldif -d $OPENLDAP_DEBUG_LEVEL


### PR DESCRIPTION
when imported  ldif file contains some objectClass the image don't have will cause error
```
ldap_add: Invalid syntax (21)
    additional info: objectClass: value #0 invalid per syntax
```
this module is quite useful , it may added by default

