### PR TITLE
Make listen URIs configurable

### DIFF
--- a/2.4.41/run-openldap.sh
+++ b/2.4.41/run-openldap.sh
@@ -9,6 +9,7 @@ OPENLDAP_ROOT_PASSWORD=${OPENLDAP_ROOT_PASSWORD:-admin}
 OPENLDAP_ROOT_DN_PREFIX=${OPENLDAP_ROOT_DN_PREFIX:-'cn=Manager'}
 OPENLDAP_ROOT_DN_SUFFIX=${OPENLDAP_ROOT_DN_SUFFIX:-'dc=example,dc=com'}
 OPENLDAP_DEBUG_LEVEL=${OPENLDAP_DEBUG_LEVEL:-256}
+OPENLDAP_LISTEN_URIS=${OPENLDAP_LISTEN_URIS:-"ldaps:/// ldap:///"}
 
 # Only run if no config has happened fully before
 if [ ! -f /etc/openldap/CONFIGURED ]; then
@@ -21,10 +22,10 @@ if [ ! -f /etc/openldap/CONFIGURED ]; then
         cp /usr/local/etc/openldap/DB_CONFIG /var/lib/ldap/DB_CONFIG
 
         # start the daemon in another process and make config changes
-        slapd -h "ldap:/// ldaps:/// ldapi:///" -d $OPENLDAP_DEBUG_LEVEL &
+        slapd -h "ldapi:///" -d $OPENLDAP_DEBUG_LEVEL &
         for ((i=30; i>0; i--))
         do
-            ping_result=`ldapsearch 2>&1 | grep "Can.t contact LDAP server"`
+            ping_result=`ldapsearch -Y EXTERNAL -H ldapi:/// 2>&1 | grep "Can.t contact LDAP server"`
             if [ -z "$ping_result" ]
             then
                 break
@@ -68,7 +69,9 @@ if [ ! -f /etc/openldap/CONFIGURED ]; then
         sed -e "s OPENLDAP_SUFFIX ${OPENLDAP_ROOT_DN_SUFFIX} g" \
             -e "s FIRST_PART ${dc_name} g" \
             usr/local/etc/openldap/base.ldif |
-            ldapadd -x -D "$OPENLDAP_ROOT_DN_PREFIX,$OPENLDAP_ROOT_DN_SUFFIX" -w "$OPENLDAP_ROOT_PASSWORD"
+            ldapadd -H ldapi:/// -x \
+	    	-D "$OPENLDAP_ROOT_DN_PREFIX,$OPENLDAP_ROOT_DN_SUFFIX" \
+		-w "$OPENLDAP_ROOT_PASSWORD"
 
         # stop the daemon
         pid=$(ps -A | grep slapd | awk '{print $1}')
@@ -120,4 +123,4 @@ if [ ! -f /etc/openldap/CONFIGURED ]; then
 fi
 
 # Start the slapd service
-exec slapd -h "ldap:/// ldaps:///" -d $OPENLDAP_DEBUG_LEVEL
+exec slapd -h "${OPENLDAP_LISTEN_URIS}" -d $OPENLDAP_DEBUG_LEVEL

--- a/README.md
+++ b/README.md
@@ -38,12 +38,13 @@ Environment variables and volumes
 The image recognizes the following environment variables that you can set during
 initialization by passing `-e VAR=VALUE` to the Docker `run` command.
 
-|    Variable name           |    Description                            | Default                   |
+| Variable name              | Description                               | Default                   |
 | :------------------------- | ----------------------------------------- | ------------------------- |
-|  `OPENLDAP_ROOT_PASSWORD`  | OpenLDAP `olcRootPW` password             | `admin`                   |
-|  `OPENLDAP_ROOT_DN_SUFFIX` | OpenLDAP `olcSuffix` suffix               | `dc=example,dc=com`       |
-|  `OPENLDAP_ROOT_DN_PREFIX` | OpenLDAP `olcRootDN` prefix               | `cn=Manager`              |
-|  `OPENLDAP_DEBUG_LEVEL`    | OpenLDAP Server Debug Level               | `256`                     |
+| `OPENLDAP_ROOT_PASSWORD`   | OpenLDAP `olcRootPW` password             | `admin`                   |
+| `OPENLDAP_ROOT_DN_SUFFIX`  | OpenLDAP `olcSuffix` suffix               | `dc=example,dc=com`       |
+| `OPENLDAP_ROOT_DN_PREFIX`  | OpenLDAP `olcRootDN` prefix               | `cn=Manager`              |
+| `OPENLDAP_DEBUG_LEVEL`     | OpenLDAP Server Debug Level               | `256`                     |
+| `OPENLDAP_LISTEN_URIS`     | OpenLDAP Server Listen URIs               | `ldaps:/// ldap:///`      |
 
 The following table details the possible debug levels.
 


### PR DESCRIPTION
Previously, slapd in this container would always listen on only
`ldaps:///` and `ldap:///`. As indicated in HACKING.md, this makes it
difficult to make configuration changes to `cn=config`.  With this
change, the user may set OPENLDAP_LISTEN_URIS to change the list of
endspoints to which slapd will listen, thus permitting the use of
`ldapi:///` if so desired.  E.g. `docker run -e
OPENLDAP_LISTEN_URIS="ldapi/// ldaps:///" ...`.

This also restricts slapd to `ldapi:///` when performing the initial
configuration steps.