### PR TITLE
add auth team as owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,11 @@
+reviewers:
+  - slaskawi
+  - stlaz
+  - s-urbaniak
+  - ibihim
+approvers:
+  - slaskawi
+  - stlaz
+  - ibihim
+  - s-urbaniak
+


### PR DESCRIPTION
# What

I would like to take ownership of this repository for the Auth Team.

# Why

- We receive bugs that are related to this repository.
- Doesn't seem to be maintained (best effort search).