### PR TITLE
Build multi-arch images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,11 @@ IMAGE_NAME := openshift/openldap
 IMAGE_PATH := $(CONTAINER_REGISTRY)/$(IMAGE_NAME)
 
 ifeq ($(TARGET),rhel7)
+	PLATFORMS ?= linux/amd64,linux/ppc64le,linux/s390x
 	IMAGE_TAG := rhel7
 	IMAGE_FILE := images/Dockerfile.rhel7
 else
+	PLATFORMS ?= linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
 	IMAGE_TAG := fedora34
 	IMAGE_FILE := images/Dockerfile
 endif
@@ -16,7 +18,8 @@ IMAGE := $(IMAGE_PATH):$(IMAGE_TAG)
 .PHONY: build
 build:
 	$(RUNTIME) build \
-		-t "$(IMAGE)" \
+		--platform $(PLATFORMS) \
+		--manifest "$(IMAGE)" \
 		-f "$(IMAGE_FILE)" \
 		.
 
@@ -25,6 +28,10 @@ test: build
 	IMAGE="$(IMAGE)" \
 	RUNTIME="$(RUNTIME)" \
 		hack/test.sh
+
+.PHONY: push
+push:
+	$(RUNTIME) manifest push $(IMAGE) $(IMAGE)
 
 .PHONY: image_name
 image_name:


### PR DESCRIPTION
This requires a recent podman, and qemu-user-static.

Note that this will not work if RUNTIME=docker is set, as its semantics for building multi-arch images is somewhat different.
